### PR TITLE
Fix score calculation to use penilaian table data

### DIFF
--- a/src/pages/AdminScoreFix.tsx
+++ b/src/pages/AdminScoreFix.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -9,7 +10,13 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { AlertTriangle, RefreshCw, CheckCircle, Users } from "lucide-react";
+import {
+  AlertTriangle,
+  RefreshCw,
+  CheckCircle,
+  Users,
+  ArrowLeft,
+} from "lucide-react";
 import {
   recalculateAllScores,
   getHighScorers,
@@ -21,6 +28,7 @@ const AdminScoreFix = () => {
   const [recalcResult, setRecalcResult] = useState<any>(null);
   const [highScorers, setHighScorers] = useState<any[]>([]);
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleRecalculate = async () => {
     setIsRecalculating(true);
@@ -86,11 +94,21 @@ const AdminScoreFix = () => {
   return (
     <div className="container mx-auto py-6 space-y-6">
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">Admin Score Fix Tool</h1>
-          <p className="text-muted-foreground">
-            Tools untuk memperbaiki dan memverifikasi scoring system
-          </p>
+        <div className="flex items-center space-x-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate("/dashboard")}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Kembali
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold">Admin Score Fix Tool</h1>
+            <p className="text-muted-foreground">
+              Tools untuk memperbaiki dan memverifikasi scoring system
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/pages/AdminScoreFix.tsx
+++ b/src/pages/AdminScoreFix.tsx
@@ -33,9 +33,9 @@ const AdminScoreFix = () => {
           title: "Recalculation Completed",
           description: `Updated ${result.updated} out of ${result.total} records`,
         });
-        
+
         // Refresh halaman ranking jika ada
-        window.dispatchEvent(new CustomEvent('ranking-refresh'));
+        window.dispatchEvent(new CustomEvent("ranking-refresh"));
       } else {
         toast({
           title: "Error",
@@ -235,86 +235,86 @@ const AdminScoreFix = () => {
                     </Badge>
                   </div>
 
-                    <div className="grid grid-cols-2 md:grid-cols-5 gap-2 text-xs">
-                      <div className="flex items-center space-x-1">
-                        <span
-                          className={
-                            scorer.pegawai?.bebas_temuan
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }
-                        >
-                          {scorer.pegawai?.bebas_temuan ? "✓" : "✗"}
-                        </span>
-                        <span>Bebas Temuan</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <span
-                          className={
-                            scorer.pegawai?.tidak_hukuman_disiplin
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }
-                        >
-                          {scorer.pegawai?.tidak_hukuman_disiplin ? "✓" : "✗"}
-                        </span>
-                        <span>No Hukuman</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <span
-                          className={
-                            scorer.pegawai?.tidak_pemeriksaan_disiplin
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }
-                        >
-                          {scorer.pegawai?.tidak_pemeriksaan_disiplin ? "✓" : "✗"}
-                        </span>
-                        <span>No Pemeriksaan</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <span
-                          className={
-                            scorer.pegawai?.memiliki_inovasi
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }
-                        >
-                          {scorer.pegawai?.memiliki_inovasi ? "✓" : "✗"}
-                        </span>
-                        <span>Inovasi</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <span
-                          className={
-                            scorer.pegawai?.memiliki_penghargaan
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }
-                        >
-                          {scorer.pegawai?.memiliki_penghargaan ? "✓" : "✗"}
-                        </span>
-                        <span>Penghargaan</span>
-                      </div>
+                  <div className="grid grid-cols-2 md:grid-cols-5 gap-2 text-xs">
+                    <div className="flex items-center space-x-1">
+                      <span
+                        className={
+                          scorer.bebas_temuan
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }
+                      >
+                        {scorer.bebas_temuan ? "✓" : "✗"}
+                      </span>
+                      <span>Bebas Temuan</span>
+                    </div>
+                    <div className="flex items-center space-x-1">
+                      <span
+                        className={
+                          scorer.tidak_hukuman_disiplin
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }
+                      >
+                        {scorer.tidak_hukuman_disiplin ? "✓" : "✗"}
+                      </span>
+                      <span>No Hukuman</span>
+                    </div>
+                    <div className="flex items-center space-x-1">
+                      <span
+                        className={
+                          scorer.tidak_pemeriksaan_disiplin
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }
+                      >
+                        {scorer.tidak_pemeriksaan_disiplin ? "✓" : "✗"}
+                      </span>
+                      <span>No Pemeriksaan</span>
+                    </div>
+                    <div className="flex items-center space-x-1">
+                      <span
+                        className={
+                          scorer.memiliki_inovasi
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }
+                      >
+                        {scorer.memiliki_inovasi ? "✓" : "✗"}
+                      </span>
+                      <span>Inovasi</span>
+                    </div>
+                    <div className="flex items-center space-x-1">
+                      <span
+                        className={
+                          scorer.memiliki_penghargaan
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }
+                      >
+                        {scorer.memiliki_penghargaan ? "✓" : "✗"}
+                      </span>
+                      <span>Penghargaan</span>
+                    </div>
                   </div>
 
-                    {/* Validation Alert */}
-                    {scorer.persentase_akhir >= 90 &&
-                      (!scorer.pegawai?.memiliki_inovasi ||
-                        !scorer.pegawai?.memiliki_penghargaan) && (
-                        <div className="bg-red-50 border border-red-200 rounded p-2 text-red-800 text-sm">
-                          ⚠️ INVALID: Score 90%+ requires both innovation AND
-                          achievement
-                        </div>
-                      )}
-
-                    {(!scorer.pegawai?.bebas_temuan ||
-                      !scorer.pegawai?.tidak_hukuman_disiplin ||
-                      !scorer.pegawai?.tidak_pemeriksaan_disiplin) && (
+                  {/* Validation Alert */}
+                  {scorer.persentase_akhir >= 90 &&
+                    (!scorer.pegawai?.memiliki_inovasi ||
+                      !scorer.pegawai?.memiliki_penghargaan) && (
                       <div className="bg-red-50 border border-red-200 rounded p-2 text-red-800 text-sm">
-                        ⚠️ INVALID: Incomplete integrity should limit score to 70%
+                        ⚠️ INVALID: Score 90%+ requires both innovation AND
+                        achievement
                       </div>
                     )}
+
+                  {(!scorer.pegawai?.bebas_temuan ||
+                    !scorer.pegawai?.tidak_hukuman_disiplin ||
+                    !scorer.pegawai?.tidak_pemeriksaan_disiplin) && (
+                    <div className="bg-red-50 border border-red-200 rounded p-2 text-red-800 text-sm">
+                      ⚠️ INVALID: Incomplete integrity should limit score to 70%
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/pages/AdminScoreFix.tsx
+++ b/src/pages/AdminScoreFix.tsx
@@ -300,17 +300,17 @@ const AdminScoreFix = () => {
 
                   {/* Validation Alert */}
                   {scorer.persentase_akhir >= 90 &&
-                    (!scorer.pegawai?.memiliki_inovasi ||
-                      !scorer.pegawai?.memiliki_penghargaan) && (
+                    (!scorer.memiliki_inovasi ||
+                      !scorer.memiliki_penghargaan) && (
                       <div className="bg-red-50 border border-red-200 rounded p-2 text-red-800 text-sm">
                         ⚠️ INVALID: Score 90%+ requires both innovation AND
                         achievement
                       </div>
                     )}
 
-                  {(!scorer.pegawai?.bebas_temuan ||
-                    !scorer.pegawai?.tidak_hukuman_disiplin ||
-                    !scorer.pegawai?.tidak_pemeriksaan_disiplin) && (
+                  {(!scorer.bebas_temuan ||
+                    !scorer.tidak_hukuman_disiplin ||
+                    !scorer.tidak_pemeriksaan_disiplin) && (
                     <div className="bg-red-50 border border-red-200 rounded p-2 text-red-800 text-sm">
                       ⚠️ INVALID: Incomplete integrity should limit score to 70%
                     </div>

--- a/src/pages/Evaluasi.tsx
+++ b/src/pages/Evaluasi.tsx
@@ -410,7 +410,7 @@ const Evaluasi = () => {
                                   : "secondary"
                               }
                             >
-                              {p.status_jabatan}
+                              {getStatusJabatanDisplay(p.status_jabatan)}
                             </Badge>
                           </TableCell>
                           <TableCell>

--- a/src/pages/Evaluasi.tsx
+++ b/src/pages/Evaluasi.tsx
@@ -324,7 +324,7 @@ const Evaluasi = () => {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">Semua Status</SelectItem>
-                    <SelectItem value="administrasi">Administrasi</SelectItem>
+                    <SelectItem value="administrasi">Administrator</SelectItem>
                     <SelectItem value="fungsional">Fungsional</SelectItem>
                   </SelectContent>
                 </Select>

--- a/src/pages/Evaluasi.tsx
+++ b/src/pages/Evaluasi.tsx
@@ -2,18 +2,24 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import { 
-  ArrowLeft, 
-  Search, 
-  ClipboardCheck, 
+import {
+  ArrowLeft,
+  Search,
+  ClipboardCheck,
   Star,
   TrendingUp,
   Users,
-  Award
+  Award,
 } from "lucide-react";
 import {
   Table,
@@ -30,6 +36,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getStatusJabatanDisplay } from "@/utils/statusJabatan";
 
 interface Pegawai {
   id: string;
@@ -71,7 +78,9 @@ const Evaluasi = () => {
   }, []);
 
   const checkAuth = async () => {
-    const { data: { session } } = await supabase.auth.getSession();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
     if (!session) {
       navigate("/auth");
     }
@@ -82,11 +91,13 @@ const Evaluasi = () => {
       // Fetch pegawai with unit kerja and latest evaluations
       const { data: pegawaiData, error: pegawaiError } = await supabase
         .from("pegawai")
-        .select(`
+        .select(
+          `
           *,
           unit_kerja:unit_kerja_id(nama_unit_kerja),
           penilaian(id, tahun_penilaian, persentase_akhir)
-        `)
+        `,
+        )
         .order("nama");
 
       if (pegawaiError) throw pegawaiError;
@@ -114,50 +125,66 @@ const Evaluasi = () => {
 
   const getLatestEvaluation = (evaluations: any[]) => {
     if (!evaluations || evaluations.length === 0) return null;
-    return evaluations.reduce((latest, current) => 
-      current.tahun_penilaian > latest.tahun_penilaian ? current : latest
+    return evaluations.reduce((latest, current) =>
+      current.tahun_penilaian > latest.tahun_penilaian ? current : latest,
     );
   };
 
   const getEvaluationStatus = (evaluations: any[]) => {
     const currentYear = new Date().getFullYear();
-    const hasCurrentYearEval = evaluations?.some(e => e.tahun_penilaian === currentYear);
-    
+    const hasCurrentYearEval = evaluations?.some(
+      (e) => e.tahun_penilaian === currentYear,
+    );
+
     if (hasCurrentYearEval) {
-      return { status: "completed", label: "Sudah Dinilai", variant: "default" as const };
+      return {
+        status: "completed",
+        label: "Sudah Dinilai",
+        variant: "default" as const,
+      };
     } else if (evaluations && evaluations.length > 0) {
-      return { status: "outdated", label: "Perlu Update", variant: "secondary" as const };
+      return {
+        status: "outdated",
+        label: "Perlu Update",
+        variant: "secondary" as const,
+      };
     } else {
-      return { status: "pending", label: "Belum Dinilai", variant: "destructive" as const };
+      return {
+        status: "pending",
+        label: "Belum Dinilai",
+        variant: "destructive" as const,
+      };
     }
   };
 
   const filteredPegawai = pegawai.filter((p) => {
-    const matchesSearch = 
+    const matchesSearch =
       p.nama.toLowerCase().includes(searchTerm.toLowerCase()) ||
       p.nip.includes(searchTerm) ||
       p.jabatan.toLowerCase().includes(searchTerm.toLowerCase());
-    
-    const matchesUnit = filterUnit === "all" || p.unit_kerja?.nama_unit_kerja === filterUnit;
-    const matchesStatus = filterStatus === "all" || p.status_jabatan === filterStatus;
+
+    const matchesUnit =
+      filterUnit === "all" || p.unit_kerja?.nama_unit_kerja === filterUnit;
+    const matchesStatus =
+      filterStatus === "all" || p.status_jabatan === filterStatus;
 
     return matchesSearch && matchesUnit && matchesStatus;
   });
 
   const stats = {
     total: pegawai.length,
-    evaluated: pegawai.filter(p => {
+    evaluated: pegawai.filter((p) => {
       const currentYear = new Date().getFullYear();
-      return p.penilaian?.some(e => e.tahun_penilaian === currentYear);
+      return p.penilaian?.some((e) => e.tahun_penilaian === currentYear);
     }).length,
-    pending: pegawai.filter(p => {
+    pending: pegawai.filter((p) => {
       const currentYear = new Date().getFullYear();
-      return !p.penilaian?.some(e => e.tahun_penilaian === currentYear);
+      return !p.penilaian?.some((e) => e.tahun_penilaian === currentYear);
     }).length,
-    highPerformers: pegawai.filter(p => {
+    highPerformers: pegawai.filter((p) => {
       const latest = getLatestEvaluation(p.penilaian);
       return latest && latest.persentase_akhir >= 85;
-    }).length
+    }).length,
   };
 
   if (isLoading) {
@@ -175,13 +202,19 @@ const Evaluasi = () => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
-              <Button variant="ghost" size="sm" onClick={() => navigate("/dashboard")}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate("/dashboard")}
+              >
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 Kembali
               </Button>
               <div>
                 <h1 className="text-2xl font-bold">Evaluasi Pegawai</h1>
-                <p className="text-sm text-muted-foreground">Lakukan penilaian kinerja pegawai ASN</p>
+                <p className="text-sm text-muted-foreground">
+                  Lakukan penilaian kinerja pegawai ASN
+                </p>
               </div>
             </div>
             <ClipboardCheck className="h-8 w-8 text-primary" />
@@ -204,7 +237,7 @@ const Evaluasi = () => {
               </div>
             </CardContent>
           </Card>
-          
+
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>Sudah Dievaluasi</CardDescription>
@@ -298,8 +331,8 @@ const Evaluasi = () => {
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium invisible">Actions</label>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   className="w-full"
                   onClick={() => {
                     setSearchTerm("");
@@ -317,7 +350,9 @@ const Evaluasi = () => {
         {/* Data Table */}
         <Card>
           <CardHeader>
-            <CardTitle>Daftar Pegawai untuk Evaluasi ({filteredPegawai.length})</CardTitle>
+            <CardTitle>
+              Daftar Pegawai untuk Evaluasi ({filteredPegawai.length})
+            </CardTitle>
             <CardDescription>
               Pilih pegawai untuk melakukan evaluasi kinerja
             </CardDescription>
@@ -328,10 +363,9 @@ const Evaluasi = () => {
                 <ClipboardCheck className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
                 <h3 className="font-semibold mb-2">Tidak ada data pegawai</h3>
                 <p className="text-muted-foreground mb-4">
-                  {pegawai.length === 0 
+                  {pegawai.length === 0
                     ? "Belum ada pegawai yang terdaftar untuk dievaluasi."
-                    : "Tidak ada pegawai yang cocok dengan filter yang dipilih."
-                  }
+                    : "Tidak ada pegawai yang cocok dengan filter yang dipilih."}
                 </p>
               </div>
             ) : (
@@ -353,13 +387,15 @@ const Evaluasi = () => {
                     {filteredPegawai.map((p) => {
                       const latestEval = getLatestEvaluation(p.penilaian);
                       const evalStatus = getEvaluationStatus(p.penilaian);
-                      
+
                       return (
                         <TableRow key={p.id}>
                           <TableCell>
                             <div>
                               <div className="font-medium">{p.nama}</div>
-                              <div className="text-sm text-muted-foreground font-mono">{p.nip}</div>
+                              <div className="text-sm text-muted-foreground font-mono">
+                                {p.nip}
+                              </div>
                             </div>
                           </TableCell>
                           <TableCell>{p.jabatan}</TableCell>
@@ -367,7 +403,13 @@ const Evaluasi = () => {
                             {p.unit_kerja?.nama_unit_kerja || "-"}
                           </TableCell>
                           <TableCell>
-                            <Badge variant={p.status_jabatan === "fungsional" ? "default" : "secondary"}>
+                            <Badge
+                              variant={
+                                p.status_jabatan === "fungsional"
+                                  ? "default"
+                                  : "secondary"
+                              }
+                            >
                               {p.status_jabatan}
                             </Badge>
                           </TableCell>
@@ -384,7 +426,9 @@ const Evaluasi = () => {
                                   <Award className="h-4 w-4 text-yellow-500" />
                                 )}
                               </div>
-                            ) : "-"}
+                            ) : (
+                              "-"
+                            )}
                           </TableCell>
                           <TableCell>
                             <Badge variant={evalStatus.variant}>
@@ -392,7 +436,7 @@ const Evaluasi = () => {
                             </Badge>
                           </TableCell>
                           <TableCell className="text-right">
-                            <Button 
+                            <Button
                               size="sm"
                               onClick={() => navigate(`/evaluasi/${p.id}`)}
                             >

--- a/src/pages/Pegawai.tsx
+++ b/src/pages/Pegawai.tsx
@@ -422,7 +422,7 @@ const Pegawai = () => {
 
           <Card>
             <CardHeader className="pb-2">
-              <CardDescription>Administrasi</CardDescription>
+              <CardDescription>Administrator</CardDescription>
               <CardTitle className="text-2xl">
                 {
                   pegawai.filter((p) => p.status_jabatan === "administrasi")

--- a/src/pages/Pegawai.tsx
+++ b/src/pages/Pegawai.tsx
@@ -306,7 +306,7 @@ const Pegawai = () => {
             row.status_jabatan === "fungsional" ? "default" : "secondary"
           }
         >
-          {row.status_jabatan}
+          {getStatusJabatanDisplay(row.status_jabatan)}
         </Badge>
       ),
     },

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -646,7 +646,7 @@ const Ranking = () => {
                                   : "secondary"
                               }
                             >
-                              {p.status_jabatan}
+                              {getStatusJabatanDisplay(p.status_jabatan)}
                             </Badge>
                           </TableCell>
                           <TableCell>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -473,7 +473,7 @@ const Ranking = () => {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">Semua Status</SelectItem>
-                    <SelectItem value="administrasi">Administrasi</SelectItem>
+                    <SelectItem value="administrasi">Administrator</SelectItem>
                     <SelectItem value="fungsional">Fungsional</SelectItem>
                   </SelectContent>
                 </Select>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -49,6 +49,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Checkbox } from "@/components/ui/checkbox";
+import { getStatusJabatanDisplay } from "@/utils/statusJabatan";
 
 interface PegawaiRanking {
   id: string;
@@ -131,14 +132,15 @@ const Ranking = () => {
   useEffect(() => {
     checkAuth();
     fetchData();
-    
+
     // Listen untuk refresh dari AdminScoreFix
     const handleRankingRefresh = () => {
       fetchData();
     };
-    
-    window.addEventListener('ranking-refresh', handleRankingRefresh);
-    return () => window.removeEventListener('ranking-refresh', handleRankingRefresh);
+
+    window.addEventListener("ranking-refresh", handleRankingRefresh);
+    return () =>
+      window.removeEventListener("ranking-refresh", handleRankingRefresh);
   }, []);
 
   useEffect(() => {

--- a/src/utils/recalculateScores.ts
+++ b/src/utils/recalculateScores.ts
@@ -192,6 +192,11 @@ export const getHighScorers = async () => {
         `
         id,
         persentase_akhir,
+        memiliki_inovasi,
+        memiliki_penghargaan,
+        bebas_temuan,
+        tidak_hukuman_disiplin,
+        tidak_pemeriksaan_disiplin,
         pegawai:pegawai_id(
           nama,
           nip,

--- a/src/utils/recalculateScores.ts
+++ b/src/utils/recalculateScores.ts
@@ -13,6 +13,13 @@ interface PenilaianData {
   leadership_score: number;
   rekam_jejak_score: number;
   prestasi_score: number;
+  // Data integritas dari penilaian table (bukan pegawai table)
+  bebas_temuan: boolean;
+  tidak_hukuman_disiplin: boolean;
+  tidak_pemeriksaan_disiplin: boolean;
+  // Data prestasi & inovasi dari penilaian table (bukan pegawai table)
+  memiliki_inovasi: boolean;
+  memiliki_penghargaan: boolean;
   pegawai: {
     bebas_temuan: boolean;
     tidak_hukuman_disiplin: boolean;
@@ -24,10 +31,11 @@ interface PenilaianData {
 
 const calculateCorrectScore = (penilaian: PenilaianData): number => {
   // Kriteria Integritas (30%) - WAJIB SEMPURNA
+  // Gunakan data dari penilaian table (bukan pegawai table) karena evaluasi bisa override data pegawai
   let integritasScore = 0;
-  if (penilaian.pegawai.bebas_temuan) integritasScore += 10;
-  if (penilaian.pegawai.tidak_hukuman_disiplin) integritasScore += 10;
-  if (penilaian.pegawai.tidak_pemeriksaan_disiplin) integritasScore += 10;
+  if (penilaian.bebas_temuan) integritasScore += 10;
+  if (penilaian.tidak_hukuman_disiplin) integritasScore += 10;
+  if (penilaian.tidak_pemeriksaan_disiplin) integritasScore += 10;
 
   // Jika integritas tidak sempurna, maksimal score adalah 70%
   if (integritasScore < 30) {
@@ -35,15 +43,16 @@ const calculateCorrectScore = (penilaian: PenilaianData): number => {
       integritasScore +
       (penilaian.skp_2_tahun_terakhir_baik ? 10 : 0) +
       (penilaian.skp_peningkatan_prestasi ? 10 : 0) +
-      (penilaian.pegawai.memiliki_inovasi ? 20 : 0) +
-      (penilaian.pegawai.memiliki_penghargaan ? 10 : 0);
+      (penilaian.memiliki_inovasi ? 20 : 0) +
+      (penilaian.memiliki_penghargaan ? 10 : 0);
     return Math.min(partialScore, 70);
   }
 
   // Prestasi & Inovasi (30%) - WAJIB MINIMAL SALAH SATU
+  // Gunakan data dari penilaian table (bukan pegawai table)
   let prestasiScore = 0;
-  if (penilaian.pegawai.memiliki_inovasi) prestasiScore += 20;
-  if (penilaian.pegawai.memiliki_penghargaan) prestasiScore += 10;
+  if (penilaian.memiliki_inovasi) prestasiScore += 20;
+  if (penilaian.memiliki_penghargaan) prestasiScore += 10;
 
   // Kriteria SKP (20%)
   let skpScore = 0;
@@ -53,7 +62,7 @@ const calculateCorrectScore = (penilaian: PenilaianData): number => {
   // Core Values ASN BerAKHLAK (20%) - menggunakan mapping ke score yang ada
   const coreValuesScores = [
     penilaian.kinerja_perilaku_score || 70, // Berorientasi Pelayanan
-    penilaian.inovasi_dampak_score || 70, // Akuntabel  
+    penilaian.inovasi_dampak_score || 70, // Akuntabel
     penilaian.inspiratif_score || 70, // Kompeten
     penilaian.komunikasi_score || 70, // Harmonis
     penilaian.kerjasama_kolaborasi_score || 70, // Loyal
@@ -64,25 +73,21 @@ const calculateCorrectScore = (penilaian: PenilaianData): number => {
   const coreValuesAverage =
     coreValuesScores.reduce((sum, score) => sum + score, 0) /
     coreValuesScores.length;
-  
+
   // Scores sudah dalam skala 1-100, convert ke 0-20 (20% dari total)
   const coreValuesScore = (coreValuesAverage / 100) * 20;
 
   let totalScore = integritasScore + prestasiScore + skpScore + coreValuesScore;
 
   // Aturan tambahan: Tanpa inovasi ATAU penghargaan, maksimal 85%
-  if (
-    !penilaian.pegawai.memiliki_inovasi &&
-    !penilaian.pegawai.memiliki_penghargaan
-  ) {
+  if (!penilaian.memiliki_inovasi && !penilaian.memiliki_penghargaan) {
     totalScore = Math.min(totalScore, 85);
   }
 
   // Aturan tambahan: Untuk score 90%+, wajib memiliki inovasi DAN penghargaan
   if (
     totalScore >= 90 &&
-    (!penilaian.pegawai.memiliki_inovasi ||
-      !penilaian.pegawai.memiliki_penghargaan)
+    (!penilaian.memiliki_inovasi || !penilaian.memiliki_penghargaan)
   ) {
     totalScore = Math.min(totalScore, 89);
   }

--- a/src/utils/recalculateScores.ts
+++ b/src/utils/recalculateScores.ts
@@ -113,6 +113,11 @@ export const recalculateAllScores = async () => {
         rekam_jejak_score,
         prestasi_score,
         persentase_akhir,
+        bebas_temuan,
+        tidak_hukuman_disiplin,
+        tidak_pemeriksaan_disiplin,
+        memiliki_inovasi,
+        memiliki_penghargaan,
         pegawai:pegawai_id(
           bebas_temuan,
           tidak_hukuman_disiplin,

--- a/src/utils/statusJabatan.ts
+++ b/src/utils/statusJabatan.ts
@@ -1,0 +1,36 @@
+/**
+ * Utility functions for handling status jabatan display and mapping
+ */
+
+/**
+ * Convert database status jabatan value to user-friendly display text
+ */
+export const getStatusJabatanDisplay = (statusJabatan: string): string => {
+  switch (statusJabatan) {
+    case "administrasi":
+      return "Administrator";
+    case "fungsional":
+      return "Fungsional";
+    default:
+      return statusJabatan; // fallback to original value
+  }
+};
+
+/**
+ * Convert user input to database value for status jabatan
+ */
+export const getStatusJabatanDbValue = (statusJabatan: string): string => {
+  const normalized = statusJabatan.toLowerCase();
+  if (["administrator", "pengawas", "pelaksana"].includes(normalized)) {
+    return "administrasi";
+  }
+  return statusJabatan;
+};
+
+/**
+ * Get all available status jabatan options for dropdowns
+ */
+export const getStatusJabatanOptions = () => [
+  { value: "administrasi", label: "Administrator" },
+  { value: "fungsional", label: "Fungsional" },
+];


### PR DESCRIPTION
Updates score calculation logic to use integrity and achievement data from the penilaian table instead of the pegawai table.

Changes made:
- Modified calculateCorrectScore function to use penilaian.bebas_temuan, penilaian.tidak_hukuman_disiplin, penilaian.tidak_pemeriksaan_disiplin instead of pegawai table equivalents
- Updated achievement fields to use penilaian.memiliki_inovasi and penilaian.memiliki_penghargaan
- Added new fields to PenilaianData interface for integrity and achievement data
- Updated database queries to fetch the new fields from penilaian table
- Modified AdminScoreFix component to display data from scorer object instead of scorer.pegawai
- Fixed indentation and quote consistency in AdminScoreFix component
- Updated validation alerts to use the correct data source

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8ea73fda92cf4d428e069ee2376544f7/orbit-den)

👀 [Preview Link](https://8ea73fda92cf4d428e069ee2376544f7-orbit-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8ea73fda92cf4d428e069ee2376544f7</projectId>-->
<!--<branchName>orbit-den</branchName>-->